### PR TITLE
移動のためにBoardクラスとAbstractKomaクラスの更新

### DIFF
--- a/AbstractKoma.pde
+++ b/AbstractKoma.pde
@@ -30,4 +30,12 @@ abstract class AbstractKoma {
     rect(this.x*SQUARESIZE, this.y*SQUARESIZE, SQUARESIZE, SQUARESIZE);
   }
 
+  void move(int toX, int toY) {
+    this.updatePos(toX, toY);
+  }
+  void updatePos(int toX, int toY) {
+    this.x=toX;
+    this.y=toY;
+    gs.turn = (gs.turn+1)%2;
+  }
 }

--- a/Board.pde
+++ b/Board.pde
@@ -16,11 +16,12 @@ class Board {
     mArea[1].draw();
     iArea.draw();
   }
-  void select(int x, int y){
+ void select(int x, int y){
     AbstractKoma koma = komaList.getSelectedKoma();
     if(koma==null){
       komaList.select(x,y);
     }else{
+      koma.move(x,y);
       koma.kStat.selected=false;
     }
   }


### PR DESCRIPTION
駒を移動させるために２クラスを更新した
これにより駒を移動させることができる
なお、動かせるのは右のコマと左のコマ交互で行える